### PR TITLE
Add Matthew Barber as paper author

### DIFF
--- a/paper.rst
+++ b/paper.rst
@@ -33,6 +33,11 @@
 :email: treddy@lanl.gov
 :institution: LANL
 
+:author: Matthew Barber
+:email: quitesimplymatt@gmail.com
+:institution: Quansight
+:equal-contributor:
+
 :author: Consortium for Python Data API Standards
 :email:
 :institution: Consortium for Python Data API Standards


### PR DESCRIPTION
Read the paper last night, and—pending TODOs obviously—it looks good to me! The test suite section I'm particular to is good.

I realise I copied the `equal-contributor` tag, not sure if we want that for all co-authors. I leave it to your discretion on whether to keep or remove that down the line.